### PR TITLE
Fix build by updating tab comparison

### DIFF
--- a/mod/src/main/java/com/example/swordforge/SwordForge.java
+++ b/mod/src/main/java/com/example/swordforge/SwordForge.java
@@ -48,7 +48,7 @@ public class SwordForge
 
     @SubscribeEvent
     public static void addCreativeTabs(BuildCreativeModeTabContentsEvent event) {
-        if (event.getTab() == CreativeModeTabs.COMBAT) {
+        if (event.getTabKey() == CreativeModeTabs.COMBAT) {
             event.accept(ModItems.COOL_SWORD.get());
         }
     }


### PR DESCRIPTION
## Summary
- fix creative tab comparison using getTabKey
- ensure build succeeds and remove binary artifacts

## Testing
- `./gradlew build --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_684614152b448332a34afa1415a11947